### PR TITLE
PLT-6985: Add Elasticsearch to Mattermost Kubernetes.

### DIFF
--- a/mattermost-helm/charts/mattermost-app/templates/config.json
+++ b/mattermost-helm/charts/mattermost-app/templates/config.json
@@ -48,12 +48,12 @@
         "EnableUserStatuses": true,
         "ClusterLogTimeoutMilliseconds": 2000
     },
-    "ElasticSearchSettings": {
-        "ConnectionUrl": "",
-        "Username": "elastic",
-        "Password": "changeme",
-        "EnableIndexing": false,
-        "EnableSearching": false,
+    "ElasticsearchSettings": {
+        "ConnectionUrl": "http://{{ .Release.Name }}-mattermost-elasticsearch:9200",
+        "Username": "",
+        "Password": "",
+        "EnableIndexing": true,
+        "EnableSearching": true,
         "Sniff": true
     },
     "TeamSettings": {

--- a/mattermost-helm/charts/mattermost-app/templates/config.json
+++ b/mattermost-helm/charts/mattermost-app/templates/config.json
@@ -52,8 +52,8 @@
         "ConnectionUrl": "http://{{ .Release.Name }}-mattermost-elasticsearch:9200",
         "Username": "",
         "Password": "",
-        "EnableIndexing": true,
-        "EnableSearching": true,
+        "EnableIndexing": {{ .Values.global.features.elasticsearch }},
+        "EnableSearching": {{ .Values.global.features.elasticsearch }},
         "Sniff": true
     },
     "TeamSettings": {

--- a/mattermost-helm/charts/mattermost-app/templates/deployment.yaml
+++ b/mattermost-helm/charts/mattermost-app/templates/deployment.yaml
@@ -57,4 +57,8 @@ spec:
             items:
             - key: mattermost.mattermost-license
               path: mattermost.mattermost-license
+      initContainers:
+        - name: init-elasticsearch
+          image: appropriate/curl:latest
+          command: ['sh', '-c', 'until curl --max-time 5 http://{{ .Release.Name }}-mattermost-elasticsearch:9200 ; do echo waiting for elasticsearch; sleep 5; done;']
 

--- a/mattermost-helm/charts/mattermost-app/templates/deployment.yaml
+++ b/mattermost-helm/charts/mattermost-app/templates/deployment.yaml
@@ -60,5 +60,5 @@ spec:
       initContainers:
         - name: init-elasticsearch
           image: appropriate/curl:latest
-          command: ['sh', '-c', 'until curl --max-time 5 http://{{ .Release.Name }}-mattermost-elasticsearch:9200 ; do echo waiting for elasticsearch; sleep 5; done;']
+          command: ['sh', '-c', 'until ! {{ .Values.global.features.elasticsearch }} || curl --max-time 5 http://{{ .Release.Name }}-mattermost-elasticsearch:9200 ; do echo waiting for elasticsearch; sleep 5; done;']
 

--- a/mattermost-helm/charts/mattermost-elasticsearch/.helmignore
+++ b/mattermost-helm/charts/mattermost-elasticsearch/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/mattermost-helm/charts/mattermost-elasticsearch/Chart.yaml
+++ b/mattermost-helm/charts/mattermost-elasticsearch/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: mattermost-elasticsearch
+version: 0.1.0

--- a/mattermost-helm/charts/mattermost-elasticsearch/templates/_helpers.tpl
+++ b/mattermost-helm/charts/mattermost-elasticsearch/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 53 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 53 chars (63 - len("-discovery")) because some Kubernetes name fields are limited to 63 (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 53 | trimSuffix "-" -}}
+{{- end -}}

--- a/mattermost-helm/charts/mattermost-elasticsearch/templates/client.yaml
+++ b/mattermost-helm/charts/mattermost-elasticsearch/templates/client.yaml
@@ -1,0 +1,74 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{template "fullname" .}}-client
+  labels:
+    component: {{template "fullname" .}}
+    role: client
+spec:
+  replicas: {{ .Values.client.replicas }}
+  template:
+    metadata:
+      labels:
+        component: {{template "fullname" .}}
+        role: client
+      annotations:
+        pod.beta.kubernetes.io/init-containers: '[
+          {
+          "name": "sysctl",
+            "image": "busybox",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sysctl", "-w", "vm.max_map_count=262144"],
+            "securityContext": {
+              "privileged": true
+            }
+          }
+        ]'
+    spec:
+      containers:
+      - name: client
+        securityContext:
+          privileged: false
+          capabilities:
+            add:
+              - IPC_LOCK
+              - SYS_RESOURCE
+        image: "{{ .Values.common.image.repository }}:{{ .Values.common.image.tag }}"
+        imagePullPolicy: {{ .Values.common.image.pullPolicy }}
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DISCOVERY_SERVICE
+          value: {{template "fullname" .}}-discovery
+        - name: NODE_DATA
+          value: "false"
+        - name: NODE_MASTER
+          value: "false"
+        - name: NODE_INGEST
+          value: "true"
+        - name: HTTP_ENABLE
+          value: "true"
+        - name: ES_JAVA_OPTS
+          value: "-Xms{{ .Values.client.heapSize }} -Xmx{{ .Values.client.heapSize }}"
+        - name: ES_PLUGINS_INSTALL
+          value: {{ .Values.common.plugins }}
+        ports:
+        - containerPort: 9200
+          name: http
+          protocol: TCP
+        - containerPort: 9300
+          name: transport
+          protocol: TCP
+        volumeMounts:
+        - name: storage
+          mountPath: /data
+      volumes:
+        - emptyDir:
+            medium: ""
+          name: "storage"

--- a/mattermost-helm/charts/mattermost-elasticsearch/templates/data.yaml
+++ b/mattermost-helm/charts/mattermost-elasticsearch/templates/data.yaml
@@ -1,0 +1,71 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{template "fullname" .}}-data
+  labels:
+    component: {{template "fullname" .}}
+    role: data
+spec:
+  replicas: {{ .Values.data.replicas }}
+  template:
+    metadata:
+      labels:
+        component: {{template "fullname" .}}
+        role: data
+      annotations:
+        pod.beta.kubernetes.io/init-containers: '[
+          {
+          "name": "sysctl",
+            "image": "busybox",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sysctl", "-w", "vm.max_map_count=262144"],
+            "securityContext": {
+              "privileged": true
+            }
+          }
+        ]'
+    spec:
+      containers:
+      - name: data
+        securityContext:
+          privileged: false
+          capabilities:
+            add:
+              - IPC_LOCK
+              - SYS_RESOURCE
+        image: "{{ .Values.common.image.repository }}:{{ .Values.common.image.tag }}"
+        imagePullPolicy: {{ .Values.common.image.pullPolicy }}
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DISCOVERY_SERVICE
+          value: {{template "fullname" .}}-discovery
+        - name: NODE_DATA
+          value: "true"
+        - name: NODE_MASTER
+          value: "false"
+        - name: NODE_INGEST
+          value: "false"
+        - name: HTTP_ENABLE
+          value: "false"
+        - name: ES_JAVA_OPTS
+          value: "-Xms{{ .Values.data.heapSize }} -Xmx{{ .Values.data.heapSize }}"
+        - name: ES_PLUGINS_INSTALL
+          value: {{ .Values.common.plugins }}
+        ports:
+        - containerPort: 9300
+          name: transport
+          protocol: TCP
+        volumeMounts:
+        - name: storage
+          mountPath: /data
+      volumes:
+        - emptyDir:
+            medium: ""
+          name: "storage"

--- a/mattermost-helm/charts/mattermost-elasticsearch/templates/discovery-svc.yaml
+++ b/mattermost-helm/charts/mattermost-elasticsearch/templates/discovery-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{template "fullname" .}}-discovery
+  labels:
+    component: {{template "fullname" .}}
+    role: master
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  selector:
+    component: {{template "fullname" .}}
+    role: master
+  ports:
+  - name: transport
+    port: 9300
+    protocol: TCP

--- a/mattermost-helm/charts/mattermost-elasticsearch/templates/master.yaml
+++ b/mattermost-helm/charts/mattermost-elasticsearch/templates/master.yaml
@@ -1,0 +1,73 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{template "fullname" .}}-master
+  labels:
+    component: {{template "fullname" .}}
+    role: master
+spec:
+  replicas: {{ .Values.master.replicas }}
+  template:
+    metadata:
+      labels:
+        component: {{template "fullname" .}}
+        role: master
+      annotations:
+        pod.beta.kubernetes.io/init-containers: '[
+          {
+          "name": "sysctl",
+            "image": "busybox",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sysctl", "-w", "vm.max_map_count=262144"],
+            "securityContext": {
+              "privileged": true
+            }
+          }
+        ]'
+    spec:
+      containers:
+      - name: master
+        securityContext:
+          privileged: false
+          capabilities:
+            add:
+              - IPC_LOCK
+              - SYS_RESOURCE
+        image: "{{ .Values.common.image.repository }}:{{ .Values.common.image.tag }}"
+        imagePullPolicy: {{ .Values.common.image.pullPolicy }}
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DISCOVERY_SERVICE
+          value: {{template "fullname" .}}-discovery
+        - name: NODE_DATA
+          value: "false"
+        - name: NODE_MASTER
+          value: "true"
+        - name: NODE_INGEST
+          value: "false"
+        - name: HTTP_ENABLE
+          value: "false"
+        - name: ES_JAVA_OPTS
+          value: "-Xms{{ .Values.master.heapSize }} -Xmx{{ .Values.master.heapSize }}"
+        - name: ES_PLUGINS_INSTALL
+          value: {{ .Values.common.plugins }}
+        - name: NUMBER_OF_MASTERS
+          value: {{ .Values.master.requiredMasters }}
+        ports:
+        - containerPort: 9300
+          name: transport
+          protocol: TCP
+        volumeMounts:
+        - name: storage
+          mountPath: /data
+      volumes:
+        - emptyDir:
+            medium: ""
+          name: "storage"

--- a/mattermost-helm/charts/mattermost-elasticsearch/templates/service.yaml
+++ b/mattermost-helm/charts/mattermost-elasticsearch/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{template "fullname" .}}
+  labels:
+    component: {{template "fullname" .}}
+    role: client
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    component: {{template "fullname" .}}
+    role: client
+  ports:
+  - name: http
+    port: {{ .Values.service.httpPort }}
+    targetPort: 9200
+    protocol: TCP
+  - name: transport
+    port: {{ .Values.service.transportPort }}
+    targetPort: 9300
+    protocol: TCP

--- a/mattermost-helm/charts/mattermost-elasticsearch/values.yaml
+++ b/mattermost-helm/charts/mattermost-elasticsearch/values.yaml
@@ -21,6 +21,6 @@ master:
 
 service:
   name: mattermost-elasticsearch
-  type: LoadBalancer
+  type: ClusterIP
   httpPort: 9200
   transportPort: 9300

--- a/mattermost-helm/charts/mattermost-elasticsearch/values.yaml
+++ b/mattermost-helm/charts/mattermost-elasticsearch/values.yaml
@@ -1,0 +1,26 @@
+common:
+  image:
+    repository: quay.io/pires/docker-elasticsearch-kubernetes
+    tag: 5.5.0
+    pullPolicy: Always
+  clusterName: mmes
+  plugins: analysis-icu
+
+client:
+  replicas: 2
+  heapSize: 128m
+
+data:
+  replicas: 2
+  heapSize: 256m
+
+master:
+  replicas: 3
+  heapSize: 128m
+  requiredMasters: "\"2\""
+
+service:
+  name: mattermost-elasticsearch
+  type: LoadBalancer
+  httpPort: 9200
+  transportPort: 9300

--- a/mattermost-helm/values.yaml
+++ b/mattermost-helm/values.yaml
@@ -18,6 +18,14 @@ mattermost-app:
 mattermost-proxy:
   replicaCount: 2
 
+mattermost-elasticsearch:
+  client:
+    replicaCount: 2
+  master:
+    replicaCount: 3
+  data:
+    replicaCount: 2
+
 mattermost-loadtest:
   numTeams: 1
   numChannelsPerTeam: 4000

--- a/mattermost-helm/values.yaml
+++ b/mattermost-helm/values.yaml
@@ -4,6 +4,8 @@ global:
   dbPassword: "passwd"
   dbName: "mattermost"
   mattermostLicense: "THIS STRING SHOULD BE REPLACED WITH THE CONTENTS OF YOUR LICENSE FILE"
+  features:
+    elasticsearch: true
 
 tags:
   core: true


### PR DESCRIPTION
Add Elasticsearch to Mattermost Kubernetes.

https://mattermost.atlassian.net/browse/PLT-6985

This more-or-less works, but has definite room for improvement.

Major Known Issues:
* Elasticsearch does not use a Persistent Volume Claim, so no data is
  stored persistently.
* If the Elasticsearch pods come up after the App Server pods, the app
  server has already failed to connect to them, so assumes Elasticsearch
  is disabled. Workaround is to kill the App Server pods so they get
  restarted. Proper fix would be some kind of probe that checks they are
  up similar to the one for the database.