### PR TITLE
Make Elasticsearch changes compatible with Kubernetes 1.5

### DIFF
--- a/mattermost-helm/charts/mattermost-app/templates/deployment.yaml
+++ b/mattermost-helm/charts/mattermost-app/templates/deployment.yaml
@@ -14,6 +14,14 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.service.metricsPort }}"
         prometheus.io/path: "/metrics"
+        pod.beta.kubernetes.io/init-containers: '[
+          {
+            "name": "init-elasticsearch",
+            "image": "appropriate/curl:latest",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sh", "-c", "until ! {{ .Values.global.features.elasticsearch }} || curl --max-time 5 http://{{ .Release.Name }}-mattermost-elasticsearch:9200 ; do echo waiting for elasticsearch; sleep 5; done;"]
+          }
+        ]'
     spec:
       containers:
       - name: {{ .Chart.Name }}
@@ -57,8 +65,3 @@ spec:
             items:
             - key: mattermost.mattermost-license
               path: mattermost.mattermost-license
-      initContainers:
-        - name: init-elasticsearch
-          image: appropriate/curl:latest
-          command: ['sh', '-c', 'until ! {{ .Values.global.features.elasticsearch }} || curl --max-time 5 http://{{ .Release.Name }}-mattermost-elasticsearch:9200 ; do echo waiting for elasticsearch; sleep 5; done;']
-


### PR DESCRIPTION
@coreyhulen this should fix the loadtests! Makes it Kubes 1.4 compatible.