### PR TITLE
Fix elasticsearch chart

### DIFF
--- a/mattermost-helm/charts/mattermost-elasticsearch/README.md
+++ b/mattermost-helm/charts/mattermost-elasticsearch/README.md
@@ -1,0 +1,8 @@
+# mattermost-elasticsearch
+
+Based on https://github.com/pires/kubernetes-elasticsearch-cluster and https://github.com/clockworksoul/helm-elasticsearch.
+
+### Important Notes
+
+* When changing `replicas` count for `master` pods make sure you also update `requiredMasters`. If there are less replicas than required, the elasticsearch cluster will not elect a leader and you will get "MasterNotDiscoveredException" errors in your client pod logs. Kubernetes may report the pod as RUNNING in this case, even though it is failing.
+* Depending on your platform (AWS, etc.) you may need to change `networkHost`. See https://github.com/pires/kubernetes-elasticsearch-cluster#no-up-and-running-site-local for more information.

--- a/mattermost-helm/charts/mattermost-elasticsearch/templates/client.yaml
+++ b/mattermost-helm/charts/mattermost-elasticsearch/templates/client.yaml
@@ -34,6 +34,8 @@ spec:
               fieldPath: metadata.name
         - name: DISCOVERY_SERVICE
           value: {{template "fullname" .}}-discovery
+        - name: NETWORK_HOST
+          value: {{ .Values.client.networkHost }}
         - name: NODE_DATA
           value: "false"
         - name: NODE_MASTER
@@ -57,6 +59,6 @@ spec:
         - name: storage
           mountPath: /data
       volumes:
-        - name: storage
-          configMap:
-            name: {{template "fullname" .}}
+      - emptyDir:
+          medium: ""
+        name: storage

--- a/mattermost-helm/charts/mattermost-elasticsearch/templates/data.yaml
+++ b/mattermost-helm/charts/mattermost-elasticsearch/templates/data.yaml
@@ -34,6 +34,8 @@ spec:
               fieldPath: metadata.name
         - name: DISCOVERY_SERVICE
           value: {{template "fullname" .}}-discovery
+        - name: NETWORK_HOST
+          value: {{ .Values.data.networkHost }}
         - name: NODE_DATA
           value: "true"
         - name: NODE_MASTER

--- a/mattermost-helm/charts/mattermost-elasticsearch/templates/master.yaml
+++ b/mattermost-helm/charts/mattermost-elasticsearch/templates/master.yaml
@@ -34,6 +34,8 @@ spec:
               fieldPath: metadata.name
         - name: DISCOVERY_SERVICE
           value: {{template "fullname" .}}-discovery
+        - name: NETWORK_HOST
+          value: {{ .Values.master.networkHost }}
         - name: NODE_DATA
           value: "false"
         - name: NODE_MASTER

--- a/mattermost-helm/charts/mattermost-elasticsearch/values.yaml
+++ b/mattermost-helm/charts/mattermost-elasticsearch/values.yaml
@@ -12,11 +12,13 @@ persistence:
 
 client:
   replicas: 2
-  heapSize: 128m
+  heapSize: 512m
+  networkHost: "_eth0:ipv4_"
 
 data:
   replicas: 2
-  heapSize: 256m
+  heapSize: 512m
+  networkHost: "_eth0:ipv4_"
 
   persistentVolume:
     ## If true, data will create/use a Persistent Volume Claim
@@ -48,7 +50,8 @@ data:
 
 master:
   replicas: 3
-  heapSize: 128m
+  heapSize: 512m
+  networkHost: "_eth0:ipv4_"
   requiredMasters: "\"2\""
 
   persistentVolume:


### PR DESCRIPTION
@crspeller I know we originally wanted to include elasticsearch via requirements.yaml but it's not in any helm repository already and we've already diverged a decent amount from the master of the helm chart this was based off. The main difference being that helm chart is using elasticsearch major version 6 and we're on major version 5.

I was also going to make all these changes in our fork of that original helm chart but I realized I don't think that's worth all the extra overhead and effort if we're just maintaining this chart separately anyways.

Eventually I think it would be nice if someone start maintaining a helm repo that we could include but for now I think it's easier if we just keep this in here.