### PR TITLE
Fix working directory for plugins

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -22,5 +22,5 @@ EXPOSE 8067
 EXPOSE 8074
 EXPOSE 8075
 
-WORKDIR /mattermost/bin
-CMD ["platform"]
+WORKDIR /mattermost
+CMD ["bin/platform"]


### PR DESCRIPTION
Working directory needs to be the top-level MM directory or plugins have an issue finding the directories they use.