### PR TITLE
Do not run loadtest automatically when starting container

### DIFF
--- a/docker/loadtest/Dockerfile
+++ b/docker/loadtest/Dockerfile
@@ -26,4 +26,4 @@ RUN mkdir -p /mattermost-load-test \
 	&& rm -f /mattermost-load-test/loadtestconfig.json
 
 WORKDIR /mattermost-load-test
-CMD ["loadtest", "all"]
+CMD ["cat"]


### PR DESCRIPTION
This means that to run the load tests you must manually go into the pods and run `loadtest all`, or use the ltops tool when my changes for that are ready. This is to make it easier to run multiple load tests from the same helm release, without having to tear it all down or delete all the load test pods. It also allows for configuration before the load tests run on the containers.