### PR TITLE
Fix license for load test chart

### DIFF
--- a/mattermost-helm/charts/mattermost-app/templates/deployment.yaml
+++ b/mattermost-helm/charts/mattermost-app/templates/deployment.yaml
@@ -67,4 +67,4 @@ spec:
               path: config.json
         - name: mattermost-license
           secret:
-            secretName: {{template "fullname" .}}-mattermost-license
+            secretName: {{ .Release.Name }}-mattermost-license

--- a/mattermost-helm/charts/mattermost-app/templates/secret-license.yaml
+++ b/mattermost-helm/charts/mattermost-app/templates/secret-license.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{template "fullname" .}}-mattermost-license
+  name: {{ .Release.Name }}-mattermost-license
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     app: {{ template "fullname" . }}

--- a/mattermost-helm/charts/mattermost-loadtest/templates/job.yaml
+++ b/mattermost-helm/charts/mattermost-loadtest/templates/job.yaml
@@ -38,7 +38,7 @@ spec:
               path: config.json
         - name: mattermost-license
           secret:
-            secretName: {{template "fullname" .}}-mattermost-license
+            secretName: {{ .Release.Name }}-mattermost-license
         - name: loadtestconfig-json
           configMap:
             name: {{template "fullname" .}}-loadtestconfig-json


### PR DESCRIPTION
The load test chart was trying to use the secret named "mattermost-loadtest-<release>-mattermost-license".