### PR TITLE
moving to initContainer spec and add readinessProbe to make sure

### DIFF
--- a/mattermost-helm/charts/mattermost-app/templates/deployment.yaml
+++ b/mattermost-helm/charts/mattermost-app/templates/deployment.yaml
@@ -14,21 +14,16 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.service.metricsPort }}"
         prometheus.io/path: "/metrics"
-        pod.beta.kubernetes.io/init-containers: '[
-          {
-            "name": "init-elasticsearch",
-            "image": "appropriate/curl:latest",
-            "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "until ! {{ .Values.global.features.elasticsearch }} || curl --max-time 5 http://{{ .Release.Name }}-mattermost-elasticsearch:9200 ; do echo waiting for elasticsearch; sleep 5; done;"]
-          },
-          {
-            "name": "init-mysql",
-            "image": "appropriate/curl:latest",
-            "imagePullPolicy": "IfNotPresent",
-            "command": ["sh", "-c", "until ! curl --max-time 5 http://{{ .Release.Name }}-mysqlha-readonly:3306 ; do echo waiting for mysql; sleep 5; done;"]
-          }
-        ]'
     spec:
+      initContainers:
+        - name: "init-elasticsearch"
+          image: "appropriate/curl:latest"
+          imagePullPolicy: "IfNotPresent"
+          command: ["sh", "-c", "until ! {{ .Values.global.features.elasticsearch.enabled }} || curl --max-time 5 http://{{ .Release.Name }}-mattermost-elasticsearch:9200 ; do echo waiting for elasticsearch; sleep 5; done; echo init-elasticsearch finished"]
+        - name: "init-mysql"
+          image: "appropriate/curl:latest"
+          imagePullPolicy: "IfNotPresent"
+          command: ["sh", "-c", "until curl --max-time 5 http://{{ .Release.Name }}-mysqlha-readonly:3306; do echo waiting for {{ .Release.Name }}-mysqlha; sleep 5; done;"]
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -44,6 +39,13 @@ spec:
           name: gossip
         livenessProbe:
           initialDelaySeconds: 90
+          timeoutSeconds: 5
+          periodSeconds: 15
+          httpGet:
+            path: /api/v4/system/ping
+            port: {{ .Values.service.internalPort }}
+        readinessProbe:
+          initialDelaySeconds: 15
           timeoutSeconds: 5
           periodSeconds: 15
           httpGet:


### PR DESCRIPTION
- Since k8s 1.6 we can use the section initContainer and then we have logs for that.
- adding readinessProbe to make sure we only start the app pods when it everything is ready