### PR TITLE
Point mysqlha at temporary chart and configure mysql slaves for faster replication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ endif
 	touch $@
 	
 package: check .init
+	# Temporary while we wait for changes to be merged upstream
+	helm repo add mattermost-mysqlha https://releases.mattermost.com/helm/mysqlha
 	mkdir -p dist
 	rm -f mattermost-helm/charts/*.tgz
 	helm package mattermost-helm/charts/* -d mattermost-helm/charts

--- a/mattermost-helm/requirements.lock
+++ b/mattermost-helm/requirements.lock
@@ -6,13 +6,13 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.17.1
 - name: mysqlha
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com
-  version: 0.2.1
+  repository: https://releases.mattermost.com/helm/mysqlha
+  version: 0.2.2
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.3.0
 - name: prometheus
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 6.7.0
-digest: sha256:76013025e636e585b435900f83cc59e330cef5dd2b4db364b81d1c1fafd2d559
-generated: 2018-06-04T13:07:14.577973186-04:00
+digest: sha256:95c64714a1d0d6b6931aa050483bed8eeeb27d45b69736ad0c584ca16e401e3a
+generated: 2018-06-05T15:50:14.629830134-04:00

--- a/mattermost-helm/requirements.yaml
+++ b/mattermost-helm/requirements.yaml
@@ -6,8 +6,8 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com
     version: 0.17.1
   - name: mysqlha
-    repository: https://kubernetes-charts-incubator.storage.googleapis.com
-    version: 0.2.1
+    repository: https://releases.mattermost.com/helm/mysqlha
+    version: 0.2.2
     condition: mysqlha.enabled
   - name: minio
     repository: https://kubernetes-charts.storage.googleapis.com

--- a/mattermost-helm/values.yaml
+++ b/mattermost-helm/values.yaml
@@ -38,6 +38,17 @@ mysqlha:
     mysqlUser: "mmuser"
     mysqlPassword: "passwd"
     mysqlDatabase: "mattermost"
+    configFiles:
+      master.cnf: |
+        [mysqld]
+        log-bin
+        skip_name_resolve
+      slave.cnf: |
+        [mysqld]
+        super-read-only
+        skip_name_resolve
+        slave_parallel_workers = 100
+        slave_parallel_type = LOGICAL_CLOCK
   persistence:
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
Temporarily hosting the mysqlha chart at https://releases.mattermost.com/helm/mysqlha until our patch is accepted upstream and released.