### PR TITLE
MM-8694: Add PostgreSQL support

### DIFF
--- a/mattermost-helm/charts/mattermost-app/templates/config.json
+++ b/mattermost-helm/charts/mattermost-app/templates/config.json
@@ -84,9 +84,15 @@
         "MaxNotificationsPerChannel": 1000
     },
     "SqlSettings": {
+        {{- if eq .Values.global.dbBackend "mysqlha" -}}
         "DriverName": "mysql",
         "DataSource": "{{ .Values.global.dbUser }}:{{ .Values.global.dbPassword }}@tcp({{ .Release.Name }}-mysqlha-0.{{ .Release.Name }}-mysqlha:3306)/{{ .Values.global.dbName }}?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
         "DataSourceReplicas": ["{{ .Values.global.dbUser }}:{{ .Values.global.dbPassword }}@tcp({{ .Release.Name }}-mysqlha-readonly:3306)/{{ .Values.global.dbName }}?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"],
+        {{- end -}}
+        {{- if eq .Values.global.dbBackend "postgresql" -}}
+        "DriverName": "postgres",
+        "DataSource": "postgres://{{ .Values.global.dbUser }}:{{ .Values.global.dbPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.global.dbName }}?sslmode=disable&connect_timeout=10",
+        {{- end -}}
         "DataSourceSearchReplicas": [],
         "MaxIdleConns": 20,
         "MaxOpenConns": 35,

--- a/mattermost-helm/charts/mattermost-app/templates/deployment.yaml
+++ b/mattermost-helm/charts/mattermost-app/templates/deployment.yaml
@@ -21,10 +21,18 @@ spec:
           image: "appropriate/curl:latest"
           imagePullPolicy: "IfNotPresent"
           command: ["sh", "-c", "until ! {{ .Values.global.features.elasticsearch.enabled }} || curl --max-time 5 http://{{ .Release.Name }}-mattermost-elasticsearch:9200 ; do echo waiting for elasticsearch; sleep 5; done; echo init-elasticsearch finished"]
+{{- if eq .Values.global.dbBackend "mysqlha" }}
         - name: "init-mysql"
           image: "appropriate/curl:latest"
           imagePullPolicy: "IfNotPresent"
           command: ["sh", "-c", "until curl --max-time 5 http://{{ .Release.Name }}-mysqlha-readonly:3306; do echo waiting for {{ .Release.Name }}-mysqlha; sleep 5; done;"]
+{{- end }}
+{{- if eq .Values.global.dbBackend "postgresql" }}
+        - name: "init-postgres"
+          image: "postgres:latest"
+          imagePullPolicy: "IfNotPresent"
+          command: ["sh", "-c", "until pg_isready -h {{ .Release.Name }}-postgresql -p 5432; do echo waiting for {{ .Release.Name }}-postgresql; sleep 5; done;"]
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/mattermost-helm/charts/mattermost-app/templates/jobserver-deployment.yaml
+++ b/mattermost-helm/charts/mattermost-app/templates/jobserver-deployment.yaml
@@ -18,10 +18,18 @@ spec:
           image: "appropriate/curl:latest"
           imagePullPolicy: "IfNotPresent"
           command: ["sh", "-c", "until ! {{ .Values.global.features.elasticsearch.enabled }} || curl --max-time 5 http://{{ .Release.Name }}-mattermost-elasticsearch:9200 ; do echo waiting for elasticsearch; sleep 5; done; echo init-elasticsearch finished"]
+        {{- if eq .Values.global.dbBackend "mysqlha" -}}
         - name: "init-mysql"
           image: "appropriate/curl:latest"
           imagePullPolicy: "IfNotPresent"
           command: ["sh", "-c", "until curl --max-time 5 http://{{ .Release.Name }}-mysqlha-readonly:3306; do echo waiting for {{ .Release.Name }}-mysqlha; sleep 5; done;"]
+        {{- end -}}
+        {{- if eq .Values.global.dbBackend "postgresql" -}}
+        - name: "init-postgres"
+          image: "postgres:latest"
+          imagePullPolicy: "IfNotPresent"
+          command: ["sh", "-c", "until pg_isready -h {{ .Release.Name }}-postgresql -p 5432; do echo waiting for {{ .Release.Name }}-postgresql; sleep 5; done;"]
+        {{- end -}}
       containers:
       - name: {{ template "mattermost-app.jobserver.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/mattermost-helm/charts/mattermost-loadtest/templates/loadtestconfig.json
+++ b/mattermost-helm/charts/mattermost-loadtest/templates/loadtestconfig.json
@@ -4,8 +4,14 @@
         "ServerURL": "http://{{ .Release.Name }}-nginx-ingress-controller",
         "WebsocketURL": "ws://{{ .Release.Name }}-nginx-ingress-controller",
         "PProfUrl": "http://{{ .Release.Name }}-mattermost-app:8067/debug/pprof",
+        {{- if eq .Values.global.dbBackend "mysqlha" -}}
         "DriverName": "mysql",
         "DataSource": "{{ .Values.global.dbUser }}:{{ .Values.global.dbPassword }}@tcp({{ .Release.Name }}-mysqlha-0.{{ .Release.Name }}-mysqlha:3306)/{{ .Values.global.dbName }}?charset=utf8mb4,utf8&readTimeout=240s&writeTimeout=240s",
+        {{- end -}}
+        {{- if eq .Values.global.dbBackend "postgresql" -}}
+        "DriverName": "postgres",
+        "DataSource": "postgres://{{ .Values.global.dbUser }}:{{ .Values.global.dbPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.global.dbName }}?sslmode=disable&connect_timeout=10",
+        {{- end -}}
         "LocalCommands": true,
         "SSHHostnamePort": "",
         "SSHUsername": "",

--- a/mattermost-helm/requirements.lock
+++ b/mattermost-helm/requirements.lock
@@ -8,11 +8,14 @@ dependencies:
 - name: mysqlha
   repository: https://kubernetes-charts-incubator.storage.googleapis.com
   version: 0.3.0
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 0.14.4
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.3.4
 - name: prometheus
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 6.7.4
-digest: sha256:f9a421bd8e6053058b26afecdae5832eccadb3c75ae9540d9c4d24f9e0e6d470
-generated: 2018-07-05T16:22:08.854104269-04:00
+digest: sha256:169a31a4e75bef47641616acd9189544059cd2ce1f18b3bfbf287a3103ff8b32
+generated: 2018-07-08T19:33:08.579843864+02:00

--- a/mattermost-helm/requirements.yaml
+++ b/mattermost-helm/requirements.yaml
@@ -15,6 +15,12 @@ dependencies:
     tags:
       - database
     condition: mysqlha.enabled
+  - name: postgresql
+    repository: https://kubernetes-charts.storage.googleapis.com
+    version: 0.14.4
+    tags:
+      - database
+    condition: postgresql.enabled
   - name: minio
     repository: https://kubernetes-charts.storage.googleapis.com
     version: 1.3.4

--- a/mattermost-helm/values.yaml
+++ b/mattermost-helm/values.yaml
@@ -1,6 +1,7 @@
 global:
   # Set siteUrl to the URL your users will use to access Mattermost
   siteUrl: ""
+  dbBackend: "mysqlha"
   dbRootPassword: "rootpasswd"
   dbUser: "mmuser"
   dbPassword: "passwd"
@@ -59,6 +60,26 @@ mysqlha:
         skip_name_resolve
         slave_parallel_workers = 100
         slave_parallel_type = LOGICAL_CLOCK
+  persistence:
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, azure-disk on
+    ##   Azure, standard on GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    ## See: https://github.com/kubernetes/charts/tree/master/incubator/mysqlha
+    enabled: false
+    size: 10Gi
+
+postgresql:
+  enabled: false
+  postgresUser: "mmuser"
+  postgresPassword: "passwd"
+  postgresDatabase: "mattermost"
   persistence:
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
Add PostgreSQL support, and allow to configure it throug values. This would be the first step for other options like patroni backend.

To test it, is easy, you simply create a values.yaml file with the content:

```
global:
  dbBackend: "postgresql"

mysqlha:
  enabled: false

postgresql:
  enabled: true
```

and then run:

```
make package
helm install dist/mattermost-helm-0.2.4.tgz -f values.yaml
```

This is for a single postgresql server.