### PR TITLE
using the mattermost-docker image

### DIFF
--- a/mattermost-helm/Chart.yaml
+++ b/mattermost-helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-helm
-version: 0.4.1
-appVersion: 5.2.1
+version: 0.5.0
+appVersion: 5.3.1
 keywords:
 - mattermost
 - communication

--- a/mattermost-helm/templates/config.tpl
+++ b/mattermost-helm/templates/config.tpl
@@ -3,7 +3,7 @@
     "ServiceSettings": {
         "SiteURL": "{{ .Values.global.siteUrl }}",
         "LicenseFileLocation": "/mattermost/mattermost.mattermost-license",
-        "ListenAddress": ":8065",
+        "ListenAddress": ":{{ .Values.mattermostApp.service.internalPort }}",
         "ConnectionSecurity": "",
         "TLSCertFile": "",
         "TLSKeyFile": "",

--- a/mattermost-helm/templates/statefull-mattermost-app.yaml
+++ b/mattermost-helm/templates/statefull-mattermost-app.yaml
@@ -26,28 +26,29 @@ spec:
         prometheus.io/path: "/metrics"
     spec:
       initContainers:
-      - name: "init-elasticsearch"
-        image: "appropriate/curl:latest"
-        imagePullPolicy: "IfNotPresent"
+      - name: init-elasticsearch
+        image: appropriate/curl:latest
+        imagePullPolicy: IfNotPresent
         command: [
           "sh",
           "-c",
           "until ! {{ .Values.global.features.elasticsearch.enabled }} || curl --max-time 5 http://{{ .Release.Name }}-mattermost-elasticsearch:9200 ; do echo waiting for elasticsearch; sleep 5; done; echo init-elasticsearch finished"]
-      - name: "init-mysql"
-        image: "appropriate/curl:latest"
-        imagePullPolicy: "IfNotPresent"
+      - name: init-mysql
+        image: appropriate/curl:latest
+        imagePullPolicy: IfNotPresent
         command: [
           "sh",
           "-c",
           "until ! {{ .Values.global.features.database.useInternal }} || curl --max-time 5 http://{{ .Release.Name }}-mysqlha-readonly:3306; do echo waiting for {{ .Release.Name }}-mysqlha; sleep 5; done;"]
-      - name: "init-config"
-        image: "busybox"
-        imagePullPolicy: "IfNotPresent"
+      - name: init-config
+        image: busybox
+        imagePullPolicy: IfNotPresent
         command:
           - sh
           - "-c"
           - |
             set -ex
+            rm -rfv /mattermost/config/lost+found
             if [[ -f /mattermost/config/config.json ]]; then
                 # If the config from configmap is the same as the config.default
                 # that means the dont have a new configmap and we dont need to
@@ -63,12 +64,30 @@ spec:
               cp /tmp/config/config.json /mattermost/config/config.json
               cp /tmp/config/config.json /mattermost/config/config.default
             fi
+            chown -R 2000:2000 /mattermost/config
         volumeMounts:
           - mountPath: /tmp/config/config.json
             name: mattermost-init-config-json
             subPath: config.json
-          - mountPath: /mattermost/config
+          - mountPath: /mattermost/config/
             name: mattermost-config
+      - name: remove-lost-found-set-permissions
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - "-c"
+        - |
+          set -ex
+          rm -rfv /mattermost/plugins/lost+found
+          rm -rfv /mattermost/client/plugins/lost+found
+          chown -R 2000:2000 /mattermost/plugins/
+          chown -R 2000:2000 /mattermost/client/plugins/
+        volumeMounts:
+        - mountPath: /mattermost/plugins/
+          name: mattermost-plugins
+        - mountPath: /mattermost/client/plugins/
+          name: mattermost-plugins-client
       containers:
       - name: {{ template "mattermost-enterprise-edition.name" . }}
         image: "{{ .Values.mattermostApp.image.repository }}:{{ .Values.mattermostApp.image.tag }}"
@@ -100,17 +119,15 @@ spec:
         - mountPath: /mattermost/mattermost.mattermost-license
           name: mattermost-license
           subPath: mattermost.mattermost-license
-        - mountPath: /mattermost/plugins
+        - mountPath: /mattermost/plugins/
           name: mattermost-plugins
-        - mountPath: /mattermost/client/plugins
+        - mountPath: /mattermost/client/plugins/
           name: mattermost-plugins-client
-        - mountPath: /mattermost/config
+        - mountPath: /mattermost/config/
           name: mattermost-config
         resources:
 {{ toYaml .Values.mattermostApp.resources | indent 10 }}
       volumes:
-      - name: tmp-files
-        emptyDir: {}
       - name: mattermost-init-config-json
         configMap:
           name: {{template "mattermost-enterprise-edition.fullname" .}}-init-config-json

--- a/mattermost-helm/templates/tests/mattermost-app-test.yaml
+++ b/mattermost-helm/templates/tests/mattermost-app-test.yaml
@@ -20,7 +20,8 @@ spec:
       name: tools
   containers:
   - name: {{ .Release.Name }}-app-test
-    image: "{{ .Values.mattermostApp.image.repository }}:{{ .Values.mattermostApp.image.tag }}"
+    image: cosmintitei/bash-curl:latest
+    imagePullPolicy: Always
     command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
     volumeMounts:
     - mountPath: /tests

--- a/mattermost-helm/values.yaml
+++ b/mattermost-helm/values.yaml
@@ -82,14 +82,14 @@ mattermostApp:
   replicaCount: 2
   image:
     repository: mattermost/mattermost-enterprise-edition
-    tag: 5.2.1
+    tag: 5.3.1
     pullPolicy: Always
 
   service:
     name: mattermost-app
     type: ClusterIP
-    externalPort: 8065
-    internalPort: 8065
+    externalPort: 8000
+    internalPort: 8000
     metricsPort: 8067
     clusterPort: 8075
     gossipPort: 8074


### PR DESCRIPTION
using the mattermost-docker image as base image

- building in jenkins the image and pushing to mattermost/mattermost-enterprise-edition docker hub
- all previous images was removed.

images with tag: 5.3.1 and latest are using the mattermost-docker dockerfile

--
Changes in the helm chart:
- set the owner of the folders
- remove lost+found
- small tweaks