### PR TITLE
MM-13091 Review, improve and test the push proxy docker image

### DIFF
--- a/docker/push-proxy/Dockerfile
+++ b/docker/push-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV APP_VERSION=4.4.0
 ENV PATH="/mattermost-push-proxy/bin:${PATH}"

--- a/docker/push-proxy/Dockerfile
+++ b/docker/push-proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-ENV PP_VERSION=4.4.0
+ENV APP_VERSION=4.4.0
 ENV PATH="/mattermost-push-proxy/bin:${PATH}"
 
 # Install some needed packages
@@ -14,18 +14,18 @@ RUN apt-get update \
 
 RUN mkdir -p /mattermost-push-proxy \
     && cd /mattermost-push-proxy \
-    && wget https://github.com/mattermost/mattermost-push-proxy/releases/download/v`echo $PP_VERSION | cut -d. -f1,2`/mattermost-push-proxy-$PP_VERSION.tar.gz \
-    && tar -xvzf mattermost-push-proxy-$PP_VERSION.tar.gz \
-    && rm mattermost-push-proxy-$PP_VERSION.tar.gz \
+    && wget https://github.com/mattermost/mattermost-push-proxy/releases/download/v`echo $APP_VERSION | cut -d. -f1,2`/mattermost-push-proxy-$APP_VERSION.tar.gz \
+    && tar -xvzf mattermost-push-proxy-$APP_VERSION.tar.gz \
+    && rm mattermost-push-proxy-$APP_VERSION.tar.gz \
     && mv mattermost-push-proxy/* ./ \
     && rm -rf mattermost-push-proxy
 
 WORKDIR /mattermost-push-proxy
+
 COPY entrypoint.sh /
-ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 8066
 
-VOLUME /mattermost-push-proxy
-VOLUME /config
-VOLUME /certs
+VOLUME ["/mattermost-push-proxy", "/config", "/certs"]
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
> MM-13091 Review, improve and test the push proxy docker image
 
- Current Dockerfile follows best practises
- Ιmpovements made include:
  - Change of PP_VERSION variable to APP_VERSION 
  - Combining of all Docker Volume creation entries in a single entry, 
  - Move of ENTRYPOINT entry to the end of the Dockerfile to follow Dockerfile best practises.
- The docker image was recreated and tested to make sure the server works as expected.

Fixes https://github.com/mattermost/mattermost-server/issues/10314