### PR TITLE
Proposed edits to PR #68

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Mattermost Enterprise Helm Chart
-==========================
+Mattermost Enterprise Edition Helm Chart
+====================================================
 
-This is the Helm chart for the Mattermost Enterprise Edition. It is subject to changes, but is used by Mattermost internally to run CI servers and our community.mattermost.com server.
+This is the Helm chart for the Mattermost Enterprise Edition. It is subject to changes, but is used by Mattermost internally to run CI servers and our [community.mattermost.com](https://community.mattermost.com) server. To learn more about Helm charts, [see the Helm docs](https://helm.sh/docs/).
 
 To read an overview of how to migrate Mattermost to Kubernetes, [see this blog post](https://mattermost.com/blog/mattermost-kubernetes/).
 
@@ -9,76 +9,78 @@ The Mattermost Team Edition Helm chart can be found [here](https://github.com/he
 
 To install the Mattermost Team Edition Helm chart in a GitLab Helm chart deployment, [see this documentation](https://docs.mattermost.com/install/install-mmte-helm-gitlab-helm.html).
 
-# Prerequisites
+# 1. Prerequisites
 
-To use the Mattermost Enterprise Helm Chart, you will first need a running Kubernetes cluster. If you do not have one, find options and installation instructions here:
+## 1.1 Kubernetes Cluster
+
+You need a running Kubernetes cluster. If you do not have one, find options and installation instructions here:
 
 https://kubernetes.io/docs/setup/pick-right-solution/ 
 
-## Helm
+## 1.2 Helm
 
 See: https://docs.helm.sh/using_helm/#quickstart
 
-Once helm is installed and initialized, run the following to add needed helm repos:
+Once helm is installed and initialized, run the following:
 
 ```bash
 helm repo add mattermost https://releases.mattermost.com/helm
 helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
 ```
 
-## Ingress
+## 1.3 Ingress
 
-To expose the application outside of your network, you'll need to configure an ingress if your Kubernetes cluster doesn't already have one.
+To expose the application outside of your network, configure an ingress if your Kubernetes cluster doesn't already have one.
 
 We suggest using [nginx-ingress](https://github.com/kubernetes/ingress-nginx), which we use internally at Mattermost.
 
 To install nginx-ingress in your Kubernetes cluster, follow [the official installation documentation](https://kubernetes.github.io/ingress-nginx/deploy/). You may also use the [helm charts](https://github.com/helm/charts/tree/master/stable/nginx-ingress) directly.
 
-To get the nginx cache to work you'll need to adjust the ConfigMap and Deployment from the above instructions. [See the ingress section of our blog post](https://mattermost.com/blog/mattermost-kubernetes/#ingress) to see how we did it for an AWS installation.
+To get the nginx cache to work, adjust the ConfigMap and Deployment from the above instructions. [See the ingress section of our blog post](https://mattermost.com/blog/mattermost-kubernetes/#ingress) to see how we did it for an AWS installation.
 
-## Certificate Manager
+## 1.4 Certificate Manager
 
-If you do not want to manually add SSL/TLS certificates, then you should install [cert-manager](https://github.com/jetstack/cert-manager). You can follow [this documentation](https://cert-manager.readthedocs.io/en/latest/) or install the [helm charts](https://github.com/helm/charts/tree/master/stable/cert-manager).
+If you do not want to manually add SSL/TLS certificates, install [cert-manager](https://github.com/jetstack/cert-manager). You can follow [this documentation](https://cert-manager.readthedocs.io/en/latest/) or install the [helm charts](https://github.com/helm/charts/tree/master/stable/cert-manager).
 
 To run with HTTPS you will need to add a Kubernetes secret for your SSL/TLS certificate, whether you use cert-manager or not.
 
-# Configuration
+# 2. Configuration
 
 To start, copy [mattermost-enterprise-edition/values.yaml](https://github.com/mattermost/mattermost-kubernetes/blob/master/mattermost-enterprise-edition/values.yaml) and name it `config.yaml`. This will be your configuration file for the Mattermost Helm chart.
 
-To understand the Mattermost configuration file, see https://docs.mattermost.com/administration/config-settings.html.
+To learn more about the Mattermost configuration file, see https://docs.mattermost.com/administration/config-settings.html.
 
-## Required Settings
+## 2.1 Required Settings
 
 At minimum there are two settings you must update: 
 
-* `global.siteURL` - set this to the URL your users will use to access Mattermost, e.g. `https://your.mattermost.com`
+* `global.siteURL` - set this to the URL your users will use to access Mattermost, e.g. `https://mattermost.example.com`
 * `global.mattermostLicense` - set this to the contents of your license file
 
 Without these two settings, Mattermost will not run correctly.
 
-## Application Version
+## 2.2 Application Version
 
 To set the Mattermost application version, update:
 
-* `mattermostApp.image.tag` - set this to the version you wish to install (e.g. `5.9.0`)
+* `mattermostApp.image.tag` - set this to the Mattermost server version you wish to install (e.g. `5.9.0`)
 
-## Ingress
+## 2.3 Ingress
 
-If you are using nginx-ingress, you need to set the following under `mattermostApp`
+If you are using nginx-ingress, set the following under `mattermostApp`:
 
 ```yaml
 ingress:
   enabled: true
   hosts:
-    - your.mattermost.com
+    - mattermost.example.com
 ```
 
-Where `your.mattermost.com` is your domain name matching what you set for `global.siteURL`. 
+where `mattermost.example.com` is your domain name and matches `global.siteURL`.
 
-### HTTPS
+### 2.3.1 HTTPS
 
-To run with HTTPS you need to have an SSL/TLS certificate added as a secret to your Kubernetes cluster, either manually or [using cert-manager](#certificate-manager).
+To run with HTTPS, add an SSL/TLS certificate as a secret to your Kubernetes cluster, either manually or [using cert-manager](#certificate-manager).
 
 Set the following under `mattermostApp` to enable HTTPS:
 
@@ -86,26 +88,26 @@ Set the following under `mattermostApp` to enable HTTPS:
 ingress:
   enabled: true
   hosts:
-    - your.mattermost.com
+    - mattermost.example.com
   tls:
     - secretName: your-tls-secret-name
       hosts:
-        - your.mattermost.com
+        - mattermost.example.com
 ```
 
-### DNS
+### 2.3.2 DNS
 
-To route users from your domain name to your Mattermost installation you must point your domain name at the external IP or domain that your ingress exposes.
+To route users from your domain name to your Mattermost installation, point your domain name at the external IP or domain that your ingress exposes.
 
 Depending on the DNS service and Ingress you're using, the steps can vary. If you are using nginx-ingress, you would do something like this:
 
 1. Run `kubectl describe svc your-nginx-ingress-controller`
-  * Replace `your-nginx-ingress-controller` with the name of your ingress controller service
-2. Copy the domain name beside "LoadBalancer Ingress:"
+    * Replace `your-nginx-ingress-controller` with the name of your ingress controller service
+2. Copy the domain name beside `LoadBalancer Ingress:`
 3. On your DNS service, create a CNAME record pointing from the domain you'd like to use to the domain name you just copied
-4. Save that and wait 10-15 minutes for the DNS change to propagate
+4. Save, and wait 10-15 minutes for the DNS change to propagate
 
-## Database
+## 2.4 Database
 
 For database configuration, you have two options:
 
@@ -114,7 +116,7 @@ For database configuration, you have two options:
 
 By default the chart uses the internal MySQL database.
 
-### Internal
+### 2.4.1 Internal
 
 We use [incubator/mysqlha](https://github.com/helm/charts/tree/master/incubator/mysqlha) to run the internal database.
 
@@ -128,7 +130,7 @@ See the [incubator/mysqlha configuration settings](https://github.com/helm/chart
 
 To backup / restore your database, please follow this [how-to](mysql-backup/README.md).
 
-### External
+### 2.4.2 External
 
 If you would like to use an external database not managed by the Mattermost Helm chart, do the following:
 
@@ -138,14 +140,14 @@ If you would like to use an external database not managed by the Mattermost Helm
 * Set `global.features.database.external.dataSource` to your master DB connection string
 * (Optional) Set `global.features.database.external.dataSourceReplicas` to an array of read replica connection strings
 
-## Push Notifications
+## 2.5 Push Notifications
 
-By default push notifications are enabled using [HPNS](https://docs.mattermost.com/mobile/mobile-hpns.html). If you would prefer to run your own push proxy, do the following:
+By default push notifications are enabled using [HPNS](https://docs.mattermost.com/mobile/mobile-hpns.html). If you prefer to run your own push proxy, do the following:
 
 * Set `global.features.notifications.useHPNS` to `false`
 * Install the push proxy Helm chart, [see instructions here](#install-push-proxy)
 
-## Storage
+## 2.6 Storage
 
 We use [stable/minio](https://github.com/helm/charts/tree/master/stable/minio) for file storage.
 
@@ -156,7 +158,7 @@ Minio is configured by default, but we recommend updating the following settings
 
 See the [stable/minio configuration settings](https://github.com/helm/charts/tree/master/stable/minio#configuration) for more options you can configure.
 
-# Install
+# 3. Install
 
 Clone this repository and cd into it:
 ```bash
@@ -181,11 +183,11 @@ To upgrade an existing release, modify the `config.yaml` with your desired chang
 helm upgrade -f config.yaml <your-release-name> ./charts/mattermost-enterprise-edition
 ```
 
-## Tearing down your Mattermost deployment
+## 3.1 Uninstalling Mattermost Enterprise Helm Chart
 
-If you are done with your deployment and want to delete it, you can use `helm delete <name>` where `<name>` is the name of your release. If you don't know the name of your release, you can use `helm ls` to find it.
+If you are done with your deployment and want to delete it, use `helm delete <your-release-name>`. If you don't know the name of your release, use `helm ls` to find it.
 
-## Install Push Proxy
+## 3.2 Install Push Proxy
 
 You can launch the Mattermost push proxy chart with:
 ```bash
@@ -198,7 +200,7 @@ To list options for mattermost-push-proxy:
 helm inspect values mattermost-push-proxy
 ```
 
-# Developing
+# 4. Developing
 
 If you are going to modify the helm charts, it is helpful to use `--dry-run` (doesn't do an actual deployment) and `--debug` (print the generated config files) when running `helm install`.
 


### PR DESCRIPTION
Proposed edits to PR #68

1 - Use `mattermost.example.com` as the host/domain, consistent with TE Helm Chart configuration doc https://github.com/helm/charts/tree/master/stable/mattermost-team-edition#example-configuration

2 - Due to the Markdown heading formatting, it was hard to read through and understand if one was still part of "Configuration" or was already a new section within the guide. Propose we numbers for the sections to help guide through the set up.

This also helps with linking to specific sections of the doc, given "Ingress" is a section heading twice (once for a prerequisite, once for a configuration)

I'm 3/5 on making the sections and linking more clear, 1/5 on proposed approach.

3 - Other minor suggestions to grammar and wording.

----

Questions:

4 - Is there value adding mattermost-enterprise-edition helm chart to https://github.com/helm/charts/tree/master/stable?

5 - Are there are any minimum version requirements for Kubernetes or Helm?

In TE Helm Chart guide, we require Kubernetes 1.8+ with Beta APIs enabled: https://github.com/helm/charts/tree/master/stable/mattermost-team-edition#prerequisites